### PR TITLE
issue#27: rhocs last dimension is allocated incorrectly in EMfields

### DIFF
--- a/fields/EMfields3D.h
+++ b/fields/EMfields3D.h
@@ -648,7 +648,7 @@ inline EMfields3D::EMfields3D(CollectiveIO * col, Grid * grid) {
   Jzh = newArr3(double, nxn, nyn, nzn);
   // involving species
   rhons = newArr4(double, ns, nxn, nyn, nzn);
-  rhocs = newArr4(double, ns, nxc, nyc, nzn);
+  rhocs = newArr4(double, ns, nxc, nyc, nzc);
   Jxs = newArr4(double, ns, nxn, nyn, nzn);
   Jys = newArr4(double, ns, nxn, nyn, nzn);
   Jzs = newArr4(double, ns, nxn, nyn, nzn);


### PR DESCRIPTION
Merge alexjohnson's "issue27" branch into "master".